### PR TITLE
Switch from /run to /tmp

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -13,11 +13,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: Gr1N/setup-poetry@v4
 
-    - name: Install dependencies
-      run: sudo apt-get install python3-pip python3-cachecontrol tox
-
-    - name: Lint code
-      run: tox -e lint
+    - run: sudo apt update
+    - run: sudo apt install python3-pip python3-cachecontrol tox
+    - run: tox -e lint
 
   unit:
     name: Unit Test
@@ -27,8 +25,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: Gr1N/setup-poetry@v4
 
-    - name: Install dependencies
-      run: sudo apt-get install python3-pip python3-cachecontrol tox
-
-    - name: Run unit tests
-      run: tox -e unit
+    - run: sudo apt update
+    - run: sudo apt install python3-pip python3-cachecontrol tox
+    - run: tox -e unit

--- a/serialized_data_interface/__init__.py
+++ b/serialized_data_interface/__init__.py
@@ -144,7 +144,7 @@ def _get_schema(schema):
     if isinstance(schema, str):
         h = hashlib.md5()
         h.update(schema.encode("utf-8"))
-        p = Path("/run") / h.hexdigest()
+        p = Path("/tmp") / h.hexdigest()
         if p.exists():
             return yaml.safe_load(p.read_text())
         else:


### PR DESCRIPTION
Running unit tests on a charm that uses the current SDI version will error out due to not having write access to /run. Switching to /tmp fixes this locally, and should generally work given that it should have 777 permissions.