### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "serialized_data_interface"
-version = "0.2.1"
+version = "0.2.3"
 description = "Serialized Data Interface for Juju Operators"
 authors = [
     "Dominik Fleischmann <dominik.fleischmann@canonical.com>",


### PR DESCRIPTION
I'm not sure why we didn't bump the version to 0.2.2 already, since that version exists already on pypi:

https://pypi.org/project/serialized-data-interface/0.2.2/

Regardless, bumping to 0.2.3 to publish recent changes