### PR TITLE
Add support for Pulling Remote Schemas after Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 __pycache__
 .tox/
 poetry.lock
+*.charm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serialized Interface Library
+# Serialized Data Interface Library
 
 https://pypi.org/project/serialized-data-interface/
 
@@ -32,6 +32,26 @@ v1:
 ```
 
 When our charms interchange data, this library will validate the data through the schema on both ends.
+
+# Usage
+In our charm metadata we would add the following lines to define our schema and the supported versions:
+
+```yaml
+provides:
+  oidc-client:
+    interface: oidc-client
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/oidc-schemas/oidc-client.yaml
+    versions: [v1]
+```
+
+In this case SDI will pull the schema from Github during deployment. If we want to deploy our charm in environments where Github isn't available we can pull the schemas during our build process by adding some lines like this in our `tox.ini` file:
+
+```
+[testenv:build]
+commands =
+    charmcraft build
+    python3 -m serialized_data_interface.local_sdi
+```
 
 # Real World Example
 

--- a/serialized_data_interface/local_sdi.py
+++ b/serialized_data_interface/local_sdi.py
@@ -1,0 +1,60 @@
+import os
+from zipfile import ZipFile, ZIP_DEFLATED
+from pathlib import Path
+from shutil import rmtree
+
+import yaml
+from .utils import get_schema, ZipFileWithPermissions
+
+
+def create_new_metadata(metadata):
+    for name, interface in metadata.get("provides", {}).items():
+        if "schema" in metadata["provides"][name]:
+            metadata["provides"][name]["schema"] = get_schema(interface["schema"])
+
+    for name, interface in metadata.get("requires", {}).items():
+        if "schema" in metadata["requires"][name]:
+            metadata["requires"][name]["schema"] = get_schema(interface["schema"])
+
+    return metadata
+
+
+def change_zip_file(charm_name, metadata):
+    temp_dir = f"{charm_name}.tmp"
+    charm_zip = f"{charm_name}.charm"
+
+    os.mkdir(temp_dir)
+
+    with ZipFileWithPermissions(f"{charm_name}.charm") as old_zip:
+        old_zip.extractall(path=temp_dir)
+
+    os.remove(charm_zip)
+
+    with ZipFile(charm_zip, "w", ZIP_DEFLATED) as new_zip:
+        for dirpath, dirnames, filenames in os.walk(temp_dir, followlinks=True):
+            dirpath = Path(dirpath)
+            for filename in filenames:
+                filepath = dirpath / filename
+                if "metadata.yaml" in filename:
+                    new_zip.writestr(
+                        str(filepath.relative_to(temp_dir)), yaml.dump(metadata)
+                    )
+                else:
+                    new_zip.write(str(filepath), str(filepath.relative_to(temp_dir)))
+
+    rmtree(temp_dir)
+
+
+def main():
+    with open("metadata.yaml", "r") as metadata_file:
+        metadata = yaml.safe_load(metadata_file)
+
+    metadata = create_new_metadata(metadata)
+
+    charm_name = metadata["name"]
+
+    change_zip_file(charm_name, metadata)
+
+
+if __name__ == "__main__":
+    main()

--- a/serialized_data_interface/utils.py
+++ b/serialized_data_interface/utils.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import hashlib
+import time
+import os
+import yaml
+from zipfile import ZipFile, ZipInfo
+
+import requests
+
+
+# Custom ZipFile class due to extractall not keeping file permissions
+# Official Python bug: https://bugs.python.org/issue15795
+class ZipFileWithPermissions(ZipFile):
+    def extract(self, member, path=None, pwd=None):
+        if not isinstance(member, ZipInfo):
+            member = self.getinfo(member)
+
+        if path is None:
+            path = os.getcwd()
+
+        ret_val = self._extract_member(member, path, pwd)
+        attr = member.external_attr >> 16
+        if attr != 0:
+            os.chmod(ret_val, attr)
+        return ret_val
+
+    def extractall(self, path=None, members=None, pwd=None):
+        if members is None:
+            members = self.namelist()
+
+        if path is None:
+            path = os.getcwd()
+        else:
+            path = os.fspath(path)
+
+        for zipinfo in members:
+            self.extract(zipinfo, path, pwd)
+
+
+def get_schema(schema):
+    """Ensures schema is retrieved if necessary, then loads it."""
+
+    if isinstance(schema, str):
+        h = hashlib.md5()
+        h.update(schema.encode("utf-8"))
+        p = Path("/tmp") / h.hexdigest()
+        if p.exists():
+            return yaml.safe_load(p.read_text())
+        else:
+            for _ in range(30):
+                try:
+                    response = requests.get(schema)
+                    response.raise_for_status()
+                    break
+                except requests.RequestException:
+                    time.sleep(5)
+            else:
+                response = requests.get(schema)
+                response.raise_for_status()
+
+            p.write_text(response.text)
+            return yaml.safe_load(response.text)
+
+    return schema

--- a/test/unit/metadata_in.yaml
+++ b/test/unit/metadata_in.yaml
@@ -1,0 +1,10 @@
+provides:
+  oidc-client:
+    interface: oidc-client
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/oidc-schemas/oidc-client.yaml
+    versions: [v1]
+requires:
+  ingress:
+    interface: ingress
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress.yaml
+    versions: [v1]

--- a/test/unit/metadata_out.yaml
+++ b/test/unit/metadata_out.yaml
@@ -1,0 +1,47 @@
+provides:
+  oidc-client:
+    interface: oidc-client
+    schema:
+      v1:
+        provides:
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            redirectURIs:
+              items:
+                type: string
+              type: array
+            secret:
+              type: string
+          required:
+          - id
+          - name
+          - redirectURIs
+          - secret
+          type: object
+    versions:
+    - v1
+requires:
+  ingress:
+    interface: ingress
+    schema:
+      v1:
+        requires:
+          properties:
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+            service:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
+          type: object
+    versions:
+    - v1

--- a/test/unit/test_local_sdi.py
+++ b/test/unit/test_local_sdi.py
@@ -1,0 +1,32 @@
+import yaml
+import os
+from zipfile import ZipFile, ZIP_DEFLATED
+
+import serialized_data_interface.local_sdi as local_sdi
+
+
+def test_create_new_metadata():
+    with open("test/unit/metadata_in.yaml") as metadata_in_file:
+        metadata_in = yaml.safe_load(metadata_in_file)
+    new_metadata = local_sdi.create_new_metadata(metadata_in)
+
+    with open("test/unit/metadata_out.yaml") as metadata_out_file:
+        metadata_out = yaml.safe_load(metadata_out_file)
+    assert metadata_out == new_metadata
+
+
+def test_change_zip_file():
+    with ZipFile("test.charm", "w", ZIP_DEFLATED) as test_zip:
+        test_zip.write("test/unit/metadata_in.yaml", "metadata.yaml")
+
+    with open("test/unit/metadata_out.yaml") as metadata_out_file:
+        metadata_out = yaml.safe_load(metadata_out_file)
+
+    local_sdi.change_zip_file("test", metadata_out)
+
+    with ZipFile("test.charm", "r") as test_zip:
+        zip_metadata = yaml.safe_load(test_zip.open("metadata.yaml"))
+
+    assert metadata_out == zip_metadata
+
+    os.remove("test.charm")

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,23 @@
+import yaml
+
+import serialized_data_interface.local_sdi as local_sdi
+
+
+def test_get_schema():
+    with open("test/unit/metadata_in.yaml") as metadata_in_file:
+        metadata_in = yaml.safe_load(metadata_in_file)
+
+    with open("test/unit/metadata_out.yaml") as metadata_out_file:
+        metadata_out = yaml.safe_load(metadata_out_file)
+
+    schema_url = metadata_in["provides"]["oidc-client"]["schema"]
+
+    # With URL
+    schema = local_sdi.get_schema(schema_url)
+
+    assert schema == metadata_out["provides"]["oidc-client"]["schema"]
+
+    # With Dict
+    schema = local_sdi.get_schema(metadata_out["provides"]["oidc-client"]["schema"])
+
+    assert schema == metadata_out["provides"]["oidc-client"]["schema"]


### PR DESCRIPTION
This allows pulling remotely hosted schemas directly into the metadata to allow charm deployments in proxy environments where these schemas might not be available.

Usage in tox:
```
[testenv:build]
commands =
    charmcraft build
    python3 -m serialized_data_interface.local_sdi
```
Also create `utils` module for reusing get_schema code and creating a custom ZipFile class (explanation in comments).