### PR TITLE
Add Charm Path option to Local SDI script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "serialized_data_interface"
-version = "0.3.0"
+version = "0.3.1"
 description = "Serialized Data Interface for Juju Operators"
 authors = [
     "Dominik Fleischmann <dominik.fleischmann@canonical.com>",


### PR DESCRIPTION
Add the option to point to a specific charm path when executing the script.

Also ensure the temporary folder is always deleted.