### PR TITLE
feature: use proxy settings from environment for pulling schemas

### DIFF
--- a/serialized_data_interface/utils.py
+++ b/serialized_data_interface/utils.py
@@ -88,19 +88,18 @@ def _get_schema_response_from_remote(schema: str) -> requests.Response:
 def _get_proxy_settings_from_env() -> dict:
     """Returns proxy settings dict inferred from environment"""
     proxies = {}
-    proxies['http'] = \
-        os.environ.get("JUJU_CHARM_HTTP_PROXY") or \
-        os.environ.get("HTTP_PROXY") or \
-        None
+    proxies["http"] = (
+        os.environ.get("JUJU_CHARM_HTTP_PROXY") or os.environ.get("HTTP_PROXY") or None
+    )
 
-    proxies['https'] = \
-        os.environ.get("JUJU_CHARM_HTTPS_PROXY") or \
-        os.environ.get("HTTPS_PROXY") or \
-        None
+    proxies["https"] = (
+        os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        or os.environ.get("HTTPS_PROXY")
+        or None
+    )
 
-    proxies['no-proxy'] = \
-        os.environ.get("JUJU_CHARM_NO_PROXY") or \
-        os.environ.get("NO_PROXY") or \
-        None
+    proxies["no-proxy"] = (
+        os.environ.get("JUJU_CHARM_NO_PROXY") or os.environ.get("NO_PROXY") or None
+    )
 
     return proxies

--- a/serialized_data_interface/utils.py
+++ b/serialized_data_interface/utils.py
@@ -40,6 +40,8 @@ class ZipFileWithPermissions(ZipFile):
 def get_schema(schema):
     """Ensures schema is retrieved if necessary, then loads it."""
 
+    print("DEBUG: in get_schema and curious if print will surface")
+
     if isinstance(schema, str):
         h = hashlib.md5()
         h.update(schema.encode("utf-8"))
@@ -49,16 +51,58 @@ def get_schema(schema):
         else:
             for _ in range(30):
                 try:
-                    response = requests.get(schema)
-                    response.raise_for_status()
+                    response = _get_schema_response_from_remote(schema)
                     break
                 except requests.RequestException:
                     time.sleep(5)
             else:
-                response = requests.get(schema)
-                response.raise_for_status()
+                response = _get_schema_response_from_remote(schema)
 
             p.write_text(response.text)
             return yaml.safe_load(response.text)
 
     return schema
+
+
+def _get_schema_response_from_remote(schema: str) -> requests.Response:
+    """
+    Returns a response object for a schema from a remote location, observing proxy settings if available
+
+    Raises for status if unsuccessful.
+
+    proxy settings for each of http, https, and no_proxy are inferred from environment variables in the order:
+        JUJU_HTTP(S)_PROXY/JUJU_NO_PROXY
+        HTTP(S)_PROXY/NO_PROXY
+
+    Args:
+        schema (str): String url to access the schema
+
+    Returns:
+        requests.Response: Schema as a Response object
+    """
+    proxies = _get_proxy_settings_from_env()
+    response = requests.get(url=schema, proxies=proxies)
+    response.raise_for_status()
+    return response
+
+
+def _get_proxy_settings_from_env() -> dict:
+    """Returns proxy settings dict inferred from environment"""
+    proxies = {}
+    proxies['http'] = \
+        os.environ.get("JUJU_CHARM_HTTP_PROXY") or \
+        os.environ.get("HTTP_PROXY") or \
+        None
+
+    proxies['https'] = \
+        os.environ.get("JUJU_CHARM_HTTPS_PROXY") or \
+        os.environ.get("HTTPS_PROXY") or \
+        None
+
+    proxies['no-proxy'] = \
+        os.environ.get("JUJU_CHARM_NO_PROXY") or \
+        os.environ.get("NO_PROXY") or \
+        None
+
+    print(f"_get_proxy_settings_from_env found proxies={proxies}")
+    return proxies

--- a/serialized_data_interface/utils.py
+++ b/serialized_data_interface/utils.py
@@ -62,7 +62,7 @@ def get_schema(schema):
     return schema
 
 
-def _get_schema_response_from_remote(schema: str) -> requests.Response:
+def _get_schema_response_from_remote(url: str) -> requests.Response:
     """
     Returns a schema response object from a remote location, observing proxy settings if available
 
@@ -74,13 +74,13 @@ def _get_schema_response_from_remote(schema: str) -> requests.Response:
         HTTP(S)_PROXY/NO_PROXY
 
     Args:
-        schema (str): String url to access the schema
+        url (str): String url to access the schema
 
     Returns:
         requests.Response: Schema as a Response object
     """
     proxies = _get_proxy_settings_from_env()
-    response = requests.get(url=schema, proxies=proxies)
+    response = requests.get(url=url, proxies=proxies)
     response.raise_for_status()
     return response
 

--- a/serialized_data_interface/utils.py
+++ b/serialized_data_interface/utils.py
@@ -40,8 +40,6 @@ class ZipFileWithPermissions(ZipFile):
 def get_schema(schema):
     """Ensures schema is retrieved if necessary, then loads it."""
 
-    print("DEBUG: in get_schema and curious if print will surface")
-
     if isinstance(schema, str):
         h = hashlib.md5()
         h.update(schema.encode("utf-8"))
@@ -66,11 +64,12 @@ def get_schema(schema):
 
 def _get_schema_response_from_remote(schema: str) -> requests.Response:
     """
-    Returns a response object for a schema from a remote location, observing proxy settings if available
+    Returns a schema response object from a remote location, observing proxy settings if available
 
     Raises for status if unsuccessful.
 
-    proxy settings for each of http, https, and no_proxy are inferred from environment variables in the order:
+    proxy settings for each of http, https, and no_proxy are inferred from environment variables
+    in the order:
         JUJU_HTTP(S)_PROXY/JUJU_NO_PROXY
         HTTP(S)_PROXY/NO_PROXY
 
@@ -104,5 +103,4 @@ def _get_proxy_settings_from_env() -> dict:
         os.environ.get("NO_PROXY") or \
         None
 
-    print(f"_get_proxy_settings_from_env found proxies={proxies}")
     return proxies

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,6 +1,10 @@
+import os
+import pytest
+from unittest import mock
 import yaml
 
 import serialized_data_interface.local_sdi as local_sdi
+from serialized_data_interface.utils import _get_proxy_settings_from_env
 
 
 def test_get_schema():
@@ -21,3 +25,66 @@ def test_get_schema():
     schema = local_sdi.get_schema(metadata_out["provides"]["oidc-client"]["schema"])
 
     assert schema == metadata_out["provides"]["oidc-client"]["schema"]
+
+
+PROXY_URLS = {i: f"http://a:800{str(i)}" for i in range(6)}
+
+
+@pytest.mark.parametrize(
+    "env_dict, expected_proxies",
+    [
+        # Null test
+        ({}, {"http": None, "https": None, "no-proxy": None}),
+        # Typical proxy args
+        (
+                {
+                    "HTTP_PROXY": PROXY_URLS[0],
+                    "HTTPS_PROXY": PROXY_URLS[1],
+                    "NO_PROXY": PROXY_URLS[2],
+                },
+                {
+                    "http": PROXY_URLS[0],
+                    "https": PROXY_URLS[1],
+                    "no-proxy": PROXY_URLS[2],
+                }
+        ),
+        # Juju proxy args
+        (
+                {
+                    "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
+                    "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
+                    "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
+                },
+                {
+                    "http": PROXY_URLS[0],
+                    "https": PROXY_URLS[1],
+                    "no-proxy": PROXY_URLS[2],
+                }
+        ),
+        # Ensure Juju take priority over regular proxy
+        (
+                {
+                    "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
+                    "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
+                    "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
+                    "HTTP_PROXY": PROXY_URLS[3],
+                    "HTTPS_PROXY": PROXY_URLS[4],
+                    "NO_PROXY": PROXY_URLS[5],
+                },
+                {
+                    "http": PROXY_URLS[0],
+                    "https": PROXY_URLS[1],
+                    "no-proxy": PROXY_URLS[2],
+                }
+        ),
+    ]
+)
+def test_get_proxy_settings_from_env(env_dict, expected_proxies):
+    # Patch the environment with our proxy settings
+    with mock.patch.dict(os.environ, env_dict, clear=True):
+        proxies = _get_proxy_settings_from_env()
+        assert proxies == expected_proxies
+
+
+# TODO (ca-scribner): Need a test that simulates a proxy to ensure we can get
+#  schema through a proxy

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -87,4 +87,5 @@ def test_get_proxy_settings_from_env(env_dict, expected_proxies):
 
 
 # TODO (ca-scribner): Need a test that simulates a proxy to ensure we can get
-#  schema through a proxy
+#  schema through a proxy.  Or, at least mock requests to make sure it gets
+#  an expected call?

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -37,47 +37,47 @@ PROXY_URLS = {i: f"http://a:800{str(i)}" for i in range(6)}
         ({}, {"http": None, "https": None, "no-proxy": None}),
         # Typical proxy args
         (
-                {
-                    "HTTP_PROXY": PROXY_URLS[0],
-                    "HTTPS_PROXY": PROXY_URLS[1],
-                    "NO_PROXY": PROXY_URLS[2],
-                },
-                {
-                    "http": PROXY_URLS[0],
-                    "https": PROXY_URLS[1],
-                    "no-proxy": PROXY_URLS[2],
-                }
+            {
+                "HTTP_PROXY": PROXY_URLS[0],
+                "HTTPS_PROXY": PROXY_URLS[1],
+                "NO_PROXY": PROXY_URLS[2],
+            },
+            {
+                "http": PROXY_URLS[0],
+                "https": PROXY_URLS[1],
+                "no-proxy": PROXY_URLS[2],
+            },
         ),
         # Juju proxy args
         (
-                {
-                    "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
-                    "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
-                    "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
-                },
-                {
-                    "http": PROXY_URLS[0],
-                    "https": PROXY_URLS[1],
-                    "no-proxy": PROXY_URLS[2],
-                }
+            {
+                "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
+                "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
+                "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
+            },
+            {
+                "http": PROXY_URLS[0],
+                "https": PROXY_URLS[1],
+                "no-proxy": PROXY_URLS[2],
+            },
         ),
         # Ensure Juju take priority over regular proxy
         (
-                {
-                    "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
-                    "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
-                    "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
-                    "HTTP_PROXY": PROXY_URLS[3],
-                    "HTTPS_PROXY": PROXY_URLS[4],
-                    "NO_PROXY": PROXY_URLS[5],
-                },
-                {
-                    "http": PROXY_URLS[0],
-                    "https": PROXY_URLS[1],
-                    "no-proxy": PROXY_URLS[2],
-                }
+            {
+                "JUJU_CHARM_HTTP_PROXY": PROXY_URLS[0],
+                "JUJU_CHARM_HTTPS_PROXY": PROXY_URLS[1],
+                "JUJU_CHARM_NO_PROXY": PROXY_URLS[2],
+                "HTTP_PROXY": PROXY_URLS[3],
+                "HTTPS_PROXY": PROXY_URLS[4],
+                "NO_PROXY": PROXY_URLS[5],
+            },
+            {
+                "http": PROXY_URLS[0],
+                "https": PROXY_URLS[1],
+                "no-proxy": PROXY_URLS[2],
+            },
         ),
-    ]
+    ],
 )
 def test_get_proxy_settings_from_env(env_dict, expected_proxies):
     # Patch the environment with our proxy settings


### PR DESCRIPTION
Fix allows for pulling schemas from behind a proxy.  Code infers proxy and no-proxy settings from environment variables `JUJU_CHARM_*_PROXY` or bare `*_PROXY` settings, in that order.

Fixes #9 