### PR TITLE
Better handling for multi-version scenarios

### DIFF
--- a/test/unit/test_multiple_schema_versions.py
+++ b/test/unit/test_multiple_schema_versions.py
@@ -1,0 +1,76 @@
+import pytest
+import serialized_data_interface as sdi
+import yaml
+from ops.charm import CharmBase
+from ops.testing import Harness
+from jsonschema.exceptions import ValidationError
+
+
+class ProvideCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        with open("test/unit/test_schema.yaml", "r") as schema:
+            self.interface = sdi.SerializedDataInterface(
+                self,
+                "app-provides",
+                yaml.safe_load(schema),
+                {"v1", "v2"},
+                "provides",
+            )
+
+
+def test_send_data_multiple_versions():
+    harness = Harness(
+        ProvideCharm,
+        meta="""
+        name: test-app
+        provides:
+            app-provides:
+                interface: serialized-data
+        """,
+    )
+    harness.set_leader(True)
+
+    rel_id1 = harness.add_relation("app-provides", "appv1")
+    harness.add_relation_unit(rel_id1, "appv1/0")
+    harness.update_relation_data(
+        rel_id1,
+        "appv1",
+        {"_supported_versions": "- v1"},
+    )
+
+    rel_id2 = harness.add_relation("app-provides", "appv2")
+    harness.add_relation_unit(rel_id2, "appv2/0")
+    harness.update_relation_data(
+        rel_id2,
+        "appv2",
+        {"_supported_versions": "- v2"},
+    )
+
+    harness.begin()
+    data = {
+        "service": "my-service",
+        "port": 4242,
+        "access-key": "my-access-key",
+        "secret-key": "my-secret-key",
+    }
+    harness.update_relation_data(rel_id1, "appv1", {"data": yaml.dump(data)})
+    harness.update_relation_data(rel_id2, "appv2", {"data": yaml.dump(data)})
+
+    harness.charm.interface.send_data(data, "appv1")
+    harness.charm.interface.send_data(
+        {"foo": "sillema sillema nika su"},
+        app_name="appv2",
+    )
+
+    # Can't send for an invalid app
+    with pytest.raises(sdi.InvalidAppName):
+        harness.charm.interface.send_data({}, "invalid-app")
+
+    # Can't send across all apps if there's multiple versions
+    with pytest.raises(sdi.AppNameOmitted):
+        harness.charm.interface.send_data(data)
+
+    # Can't send invalid data
+    with pytest.raises(ValidationError):
+        harness.charm.interface.send_data({}, "appv2")

--- a/test/unit/test_provide_interface.py
+++ b/test/unit/test_provide_interface.py
@@ -44,7 +44,7 @@ def test_provide_one_relation():
         """,
     )
     harness.set_leader(True)
-    rel_id = harness.add_relation("app-requires", "foo")
+    rel_id = harness.add_relation("app-provides", "foo")
     harness.add_relation_unit(rel_id, "foo/0")
     harness.update_relation_data(
         rel_id,

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ whitelist_externals = poetry
 [testenv:unit]
 commands =
     poetry install -v
-    poetry run pytest test/unit/
+    poetry run pytest -vvs test/unit/
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
Adds optional param to send_data to send for a specific app for a given relation, and checks that charm isn't sending the same data to all other apps if they have multiple different agreed-upon schema versions.

Also fixes bug where send_data wasn't actually validating sent data with the schema, and fixes typo in unit tests.