### PR TITLE
Remove Object -> SDI inheritance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "serialized_data_interface"
-version = "0.3.3"
+version = "0.3.4"
 description = "Serialized Data Interface for Juju Operators"
 authors = [
     "Dominik Fleischmann <dominik.fleischmann@canonical.com>",

--- a/test/unit/metadata_out.yaml
+++ b/test/unit/metadata_out.yaml
@@ -27,6 +27,25 @@ requires:
   ingress:
     interface: ingress
     schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+            - service
+            - port
+            - namespace
+            - prefix
       v1:
         requires:
           properties:


### PR DESCRIPTION
I don't remember why we did this in the first place, but it breaks instantiating a single SDI instance in an event handler, due to RunTimeError. Tested with `istio-gateway` charm, and removing inheritance had no effect on unit tests.

The exact error was:

    RuntimeError: two objects claiming to be Operator/SerializedDataInterface[istio-pilot] have been created