### PR TITLE
Add {posargs} to tox unit test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     poetry
 commands =
     poetry install -v
-    poetry run pytest -vvs test/unit/
+    poetry run pytest -vvs test/unit/ {posargs}
 
 [testenv:lint]
 setenv =


### PR DESCRIPTION
Allows specifying pytest args from tox cli