### PR TITLE
Exclude self app in get_data

### DIFF
--- a/serialized_data_interface/__init__.py
+++ b/serialized_data_interface/__init__.py
@@ -158,16 +158,12 @@ class SerializedDataInterface:
             (relation, app): yaml.safe_load(bag["data"])
             for relation in self._relations
             for app, bag in relation.data.items()
-            if isinstance(app, Application) and "data" in bag
+            if isinstance(app, Application) and not app._is_our_app and "data" in bag
         }
 
         for (rel, app), datum in data.items():
             if datum:
-                schema = self.schema[self.versions[rel.app.name]]
-                if app._is_our_app:
-                    schema = schema[self.end]
-                else:
-                    schema = schema[other]
+                schema = self.schema[self.versions[app.name]][other]
 
                 validate(instance=datum, schema=schema)
 

--- a/test/unit/test_dual_interface.py
+++ b/test/unit/test_dual_interface.py
@@ -47,8 +47,8 @@ def test_dual_interface_charm():
 
     rel_data = harness.charm.interface.get_data()
     assert rel_data == {
-        (rel, app): {"bar": None} if app._is_our_app else {"foo": "bar"}
+        (rel, app): {"foo": "bar"}
         for rel in harness.model.relations["app-requires"]
         for app, bag in rel.data.items()
-        if isinstance(app, Application) and "data" in bag
+        if isinstance(app, Application) and not app._is_our_app
     }

--- a/test/unit/test_provide_interface.py
+++ b/test/unit/test_provide_interface.py
@@ -1,6 +1,5 @@
 import yaml
 from ops.charm import CharmBase
-from ops.model import Application
 from ops.testing import Harness
 
 from serialized_data_interface import SerializedDataInterface
@@ -61,13 +60,7 @@ def test_provide_one_relation():
         "secret-key": "my-secret-key",
     }
     harness.charm.interface.send_data(data)
-    rel_data = harness.charm.interface.get_data()
-    assert rel_data == {
-        (rel, app): data
-        for rel in harness.model.relations["app-provides"]
-        for app, bag in rel.data.items()
-        if isinstance(app, Application) and "data" in bag
-    }
+    assert harness.charm.interface.get_data() == {}
 
 
 def test_provide_many_relations():
@@ -104,10 +97,4 @@ def test_provide_many_relations():
         "secret-key": "my-secret-key",
     }
     harness.charm.interface.send_data(data)
-    rel_data = harness.charm.interface.get_data()
-    assert rel_data == {
-        (rel, app): data
-        for rel in harness.model.relations["app-provides"]
-        for app, bag in rel.data.items()
-        if isinstance(app, Application) and "data" in bag
-    }
+    assert harness.charm.interface.get_data() == {}


### PR DESCRIPTION
It was included for use cases that aren't very common but may happen. Since those use cases are uncommon to non-existent, put that functionality behind a flag.