### PR TITLE
Enable non-leaders to read response data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "serialized_data_interface"
-version = "0.3.4"
+version = "0.3.5"
 description = "Serialized Data Interface for Juju Operators"
 authors = [
     "Dominik Fleischmann <dominik.fleischmann@canonical.com>",

--- a/test/unit/test_schema.yaml
+++ b/test/unit/test_schema.yaml
@@ -10,6 +10,11 @@ v1:
         type: string
       secret-key:
         type: string
+  requires:
+    type: object
+    properties:
+      response:
+        type: string
 v2:
   provides:
     required: [foo]


### PR DESCRIPTION
Non-leaders can't send data nor can they read sent data, but they should be able to read any response data that comes back.

Fixes #27