### PR TITLE
Gracefully handle empty remote app name

### DIFF
--- a/serialized_data_interface/__init__.py
+++ b/serialized_data_interface/__init__.py
@@ -111,7 +111,7 @@ class SerializedDataInterface:
             app.name: bag.get("_supported_versions")
             for relation in charm.model.relations[relation_name]
             for app, bag in relation.data.items()
-            if isinstance(app, Application) and not app._is_our_app
+            if isinstance(app, Application) and app.name and not app._is_our_app
         }
 
         unversioned = [name for name, versions in others.items() if versions is None]

--- a/test/unit/test_require_interface.py
+++ b/test/unit/test_require_interface.py
@@ -1,9 +1,9 @@
-import pytest
-import yaml
 from unittest.mock import MagicMock
 
+import pytest
+import yaml
 from ops.charm import CharmBase
-from ops.model import Application, RelationDataError, ModelError
+from ops.model import Application, ModelError, RelationDataError
 from ops.testing import Harness
 
 import serialized_data_interface as sdi

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,11 @@ max-line-length = 100
 skipsdist = True
 
 [testenv:unit]
+setenv =
+    PYTHONBREAKPOINT=ipdb.set_trace
 deps =
     poetry
+    ipdb
 commands =
     poetry install -v
     poetry run pytest -vvs test/unit/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,8 @@ max-line-length = 100
 skipsdist = True
 
 [testenv:unit]
-setenv =
-    PYTHONBREAKPOINT=ipdb.set_trace
 deps =
     poetry
-    ipdb
 commands =
     poetry install -v
     poetry run pytest -vvs test/unit/ {posargs}


### PR DESCRIPTION
It shouldn't ever happen but it seems that the remote app name can be set to blank during a relation-broken hook in some strange edge case which leads to a `ModelError` during `SDI.__init__()`. This handles that case more gracefully.

Fixes #34