### PR TITLE
Fix _send_auto_data to require leadership

### DIFF
--- a/serialized_data_interface/relation.py
+++ b/serialized_data_interface/relation.py
@@ -269,7 +269,7 @@ class EndpointWrapper(Object):
         self._sdi.send_versions(relation)
 
     def _send_auto_data(self, relation):
-        if self.auto_data and self.is_available(relation):
+        if self.auto_data and self.is_available(relation) and self.unit.is_leader():
             self.wrap(relation, self.auto_data)
 
     def unwrap(self, relation: Relation):


### PR DESCRIPTION
I *think* this is correct. I was running into an issue where SDI was trying to set `auto_data` in the application data bag from a non-leader unit. 

This seems to fix that - but this is my first proper foray into this codebase, so comments welcome!