### PR TITLE
fix: update access to relation data for tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - uses: Gr1N/setup-poetry@v8
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - uses: Gr1N/setup-poetry@v8
 
     - run: sudo apt update
     - run: sudo apt install python3-pip python3-cachecontrol tox

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -7,11 +7,14 @@ on:
 jobs:
   lint:
     name: Lint Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: Gr1N/setup-poetry@v4
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - uses: Gr1N/setup-poetry@v8
 
     - run: sudo apt update
     - run: sudo apt install python3-pip python3-cachecontrol tox
@@ -22,8 +25,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: Gr1N/setup-poetry@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: Gr1N/setup-poetry@v8
 
     - run: sudo apt update
     - run: sudo apt install python3-pip python3-cachecontrol tox

--- a/test/unit/test_require_interface.py
+++ b/test/unit/test_require_interface.py
@@ -174,7 +174,7 @@ def test_missing_remote_app_name():
     rel_id = harness.add_relation("app-requires", "")
     # not ideal, but I couldn't get it to work w/ harness.update_relation_data()
     # due to it doing several copy operations internally
-    harness._backend._relation_data[rel_id][""] = exploding_bag
+    harness._backend._relation_data_raw[rel_id][""] = exploding_bag
 
     # confirm that setting up the charm does not explode
     harness.begin()


### PR DESCRIPTION
This updates the naming of a (private) method on the harness._backend that we use in our unit tests.  It was renamed in a recent `ops` package update