### PR TITLE
fix: loosen the pinning of our dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 
-jsonschema = "3.2"
-ops = "^2"
-pyyaml = "^6"
-requests = "2.25"
+jsonschema
+ops
+pyyaml
+requests
 
 [tool.poetry.dev-dependencies]
 black = "20.8b1"


### PR DESCRIPTION
This PR loosens our package pinning to avoid conflicts with other packages.  Previously, we had strictly pinned versions even though we did not need to be that strict (other packages would have been ok).  This would cause conflicts with other packages that were also strict.