### PR TITLE
build: unpin ops so it can be updated to most recent versions (#42)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: Gr1N/setup-poetry@v4
+    - uses: Gr1N/setup-poetry@v8
 
     - run: sudo apt update
     - run: sudo apt install python3-pip python3-cachecontrol tox
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: Gr1N/setup-poetry@v4
+    - uses: Gr1N/setup-poetry@v8
 
     - run: sudo apt update
     - run: sudo apt install python3-pip python3-cachecontrol tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 python = "^3.8"
 
 jsonschema = "3.2"
-ops = "^1.2"
+ops = "^2"
 pyyaml = "5.4"
 requests = "2.25"
 

--- a/test/unit/test_require_interface.py
+++ b/test/unit/test_require_interface.py
@@ -168,9 +168,7 @@ def test_missing_remote_app_name():
     )
     harness.set_leader(False)
     rel_id = harness.add_relation("app-requires", "")
-    # not ideal, but I couldn't get it to work w/ harness.update_relation_data()
-    # due to it doing several copy operations internally
-    harness._backend._relation_data[rel_id][""] = exploding_bag
+    harness.update_relation_data(rel_id, "", exploding_bag)
 
     # confirm that setting up the charm does not explode
     harness.begin()


### PR DESCRIPTION
* build: pin ops so it can be updated to most recent versions

Fixes #41


* fix: bump poetry install action to working version

* tests: use update_relation_data()

---------